### PR TITLE
chore: 作業ディレクトリを gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ dist
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+.agents/
+.playwright-cli/


### PR DESCRIPTION
## 概要
- repo ルートの `.gitignore` に `.agents/` と `.playwright-cli/` を追加しました
- ローカル作業用ディレクトリが `git status` に出続けないように整理しました

## 確認
- `printf '.agents/foo\n.playwright-cli/foo\n' | git check-ignore -v --stdin`
